### PR TITLE
feat(tail,cli,query): add tailing (portable + Linux inotify), field-b…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -Iinclude -Isrc
-SRC = src/main.c src/logfire.c src/parser.c src/query.c src/formatter.c src/cli.c
+SRC = src/main.c src/logfire.c src/parser.c src/query.c src/formatter.c src/cli.c src/tail.c
 OUT = logfire
 
 all:

--- a/include/cli.h
+++ b/include/cli.h
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2025 Adolph Mapunda
+ */
 #ifndef CLI_H
 #define CLI_H
 
@@ -12,13 +16,16 @@ typedef enum
 
 typedef struct
 {
-    const char **inputs; // array of input paths; we use "-" for stdin
+    const char **inputs;
     int input_count;
-    const char *searchTerm; // may be NULL or ""
-    OutputFormat format;    // FORMAT_TEXT / FORMAT_JSON / FORMAT_CSV
-    const char *outputFile; // nullable
-    int strict;             // print parse errors/unknown lines to stderr
-    int case_insensitive;   // case-insensitive search
+    const char *searchTerm;
+    const char *query;
+    OutputFormat format;
+    const char *outputFile;
+    int strict;
+    int case_insensitive;
+    int tail;
+    int from_start;
 } CLIOptions;
 
 CLIOptions parseCLI(int argc, char *argv[]);

--- a/include/formatter.h
+++ b/include/formatter.h
@@ -17,6 +17,5 @@ enum OutputFormat
 void printLogText(LogEntry *entry, FILE *out);
 void printLogJSON(LogEntry *entry, FILE *out);
 void printLogCSV(LogEntry *entry, FILE *out);
-void printFormatted(LogEntry *entry, enum OutputFormat fmt, FILE *out);
- 
+
 #endif // FORMATTER_H

--- a/include/jsonout.h
+++ b/include/jsonout.h
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2025 Adolph Mapunda
+ */
 #ifndef JSONOUT_H
 #define JSONOUT_H
 #include <stdio.h>

--- a/include/logstore.h
+++ b/include/logstore.h
@@ -4,6 +4,7 @@
  */
 #ifndef LOGSTORE_H
 #define LOGSTORE_H
+#include <time.h>
 
 typedef struct
 {
@@ -13,6 +14,7 @@ typedef struct
     char url[1024];
     int status;
     char userAgent[1024];
+    time_t epoch;
 } LogEntry;
 
 #endif // LOGSTORE_H

--- a/include/query.h
+++ b/include/query.h
@@ -1,7 +1,52 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2025 Adolph Mapunda
+ */
 #ifndef QUERY_H
 #define QUERY_H
 #include "logstore.h"
 
-int matches(const LogEntry *e, const char *needle, int ci); // returns 1 if the entry matches 'needle', 0 otherwise. Case-insensitive if ci!=0.
+typedef enum
+{
+    QF_STATUS,
+    QF_IP,
+    QF_METHOD,
+    QF_URL,
+    QF_TIMESTAMP,
+    QF_USERAGENT
+} QueryField;
+
+typedef enum
+{
+    QOP_EQ,
+    QOP_NE,
+    QOP_GT,
+    QOP_LT,
+    QOP_GTE,
+    QOP_LTE,
+    QOP_CONTAINS // ':' maps to EQ for numeric, CONTAINS/wildcard for strings
+} QueryOp;
+
+typedef struct
+{
+    QueryField field;
+    QueryOp op;
+    char value[1024]; // raw value (string); for status/timestamp we also pre-parse
+    int value_i;      // numeric (status) if applicable
+    time_t value_t;   // timestamp if applicable
+    int has_i;
+    int has_t;
+} QueryTerm;
+
+typedef struct
+{
+    QueryTerm terms[16]; // up to 16 AND terms v1
+    int count;
+    int case_insensitive;
+} Query;
+
+int query_parse(const char *expr, int case_insensitive, Query *out, char *errmsg, size_t errmsg_sz);
+int query_match(const LogEntry *e, const Query *q);
+int matches(const LogEntry *e, const char *needle, int case_insensitive);
 
 #endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -35,7 +35,6 @@ int parse_apache_or_nginx(const char *line, LogEntry *out, char *errmsg, size_t 
                          ip, timebuf, method, url, proto, &status, ua); // we use scansets to grab inside [] and ""
 
     if (matched < 6)
-
     { // be lenient; require at least ip,time,method,url,proto,status
         if (errmsg && errmsg_sz)
             snprintf(errmsg, errmsg_sz, "sscanf matched %d fields", matched);
@@ -47,7 +46,7 @@ int parse_apache_or_nginx(const char *line, LogEntry *out, char *errmsg, size_t 
     strncpy(out->method, method, sizeof(out->method) - 1);
     strncpy(out->url, url, sizeof(out->url) - 1);
     out->status = status;
-    strncpy(out->userAgent, ua, sizeof(out->userAgent) - 1);
+    strncpy(out->userAgent, ua, sizeof(out->userAgent) - 1);  
 
     return 1;
 }

--- a/src/query.c
+++ b/src/query.c
@@ -1,61 +1,389 @@
-#include <string.h>
-#include "query.h"
-#include <logstore.h>
-
-/**
- * @brief Checks if the string `h` contains the substring `n`, case-insensitively.
- *
- * This function performs a case-insensitive search to determine whether the string
- * `h` contains the substring `n`. If either `h` or `n` is NULL, the function returns 0.
- * If `n` is an empty string, the function returns 1.
- *
- * @param h The string to be searched (haystack).
- * @param n The substring to search for (needle).
- * @return int Returns 1 if `h` contains `n` (case-insensitive), 0 otherwise.
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2025 Adolph Mapunda
  */
-static int contains_ci(const char *h, const char *n)
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <time.h>
+#include "query.h"
+#include "logstore.h"
+
+static int icasecmp(char a, char b)
 {
-    if (!h || !n)
+    if (a >= 'A' && a <= 'Z')
+        a += 32;
+    if (b >= 'A' && b <= 'Z')
+        b += 32;
+    return (unsigned char)a - (unsigned char)b;
+}
+
+static int str_eq_ci(const char *a, const char *b)
+{
+    for (; *a && *b; a++, b++)
+    {
+        if (icasecmp(*a, *b))
+            return 0;
+    }
+    return *a == 0 && *b == 0;
+}
+
+// simple wildcard match (* ?), case-insensitive optional
+static int wildcard_match(const char *s, const char *pat, int ci)
+{
+    const char *star = NULL, *ss = NULL;
+    while (*s)
+    {
+        if (*pat == '*')
+        {
+            star = ++pat;
+            ss = s;
+        }
+        else if (*pat == '?' || (!ci && *pat == *s) || (ci && !icasecmp(*pat, *s)))
+        {
+            pat++;
+            s++;
+        }
+        else if (star)
+        {
+            pat = star;
+            s = ++ss;
+        }
+        else
+            return 0;
+    }
+    while (*pat == '*')
+        pat++;
+    return *pat == 0;
+}
+
+// parse ISO 8601 "YYYY-MM-DDTHH:MM:SS" (assume UTC)
+static int parse_iso_utc(const char *str, time_t *out)
+{
+    int Y, M, D, h, m;
+    int s;
+    if (sscanf(str, "%4d-%2d-%2dT%2d:%2d:%2d", &Y, &M, &D, &h, &m, &s) != 6)
         return 0;
-    size_t hl = strlen(h), nl = strlen(n);
-    if (nl == 0)
+    struct tm tmz;
+    memset(&tmz, 0, sizeof(tmz));
+    tmz.tm_year = Y - 1900;
+    tmz.tm_mon = M - 1;
+    tmz.tm_mday = D;
+    tmz.tm_hour = h;
+    tmz.tm_min = m;
+    tmz.tm_sec = s;
+// timegm replacement: assume environment is UTC; on Windows use _mkgmtime
+#ifdef _WIN32
+    *out = _mkgmtime(&tmz);
+#else
+    *out = timegm(&tmz);
+#endif
+    return (*out != (time_t)-1);
+}
+
+// trim surrounding quotes if present
+static void unquote(char *s)
+{
+    size_t n = strlen(s);
+    if (n >= 2 && ((s[0] == '"' && s[n - 1] == '"') || (s[0] == '\'' && s[n - 1] == '\'')))
+    {
+        memmove(s, s + 1, n - 2);
+        s[n - 2] = '\0';
+    }
+}
+
+// map field name
+static int map_field(const char *name, QueryField *out)
+{
+    if (str_eq_ci(name, "status"))
+    {
+        *out = QF_STATUS;
         return 1;
-    for (size_t i = 0; i + nl <= hl; i++)
+    }
+    if (str_eq_ci(name, "ip"))
+    {
+        *out = QF_IP;
+        return 1;
+    }
+    if (str_eq_ci(name, "method"))
+    {
+        *out = QF_METHOD;
+        return 1;
+    }
+    if (str_eq_ci(name, "url"))
+    {
+        *out = QF_URL;
+        return 1;
+    }
+    if (str_eq_ci(name, "timestamp"))
+    {
+        *out = QF_TIMESTAMP;
+        return 1;
+    }
+    if (str_eq_ci(name, "useragent"))
+    {
+        *out = QF_USERAGENT;
+        return 1;
+    }
+    return 0;
+}
+
+// detect operator and split "field<op>value"
+static int split_token(char *tok, char *field, char *op, char *val)
+{
+    // try two-char ops first
+    const char *ops2[] = {">=", "<=", "!=", NULL};
+    for (int i = 0; ops2[i]; i++)
+    {
+        char *p = strstr(tok, ops2[i]);
+        if (p)
+        {
+            strncpy(field, tok, p - tok);
+            field[p - tok] = 0;
+            strcpy(op, ops2[i]);
+            strcpy(val, p + 2);
+            return 1;
+        }
+    }
+    // one-char ops
+    const char *ops1 = ":=><";
+    for (const char *q = tok; *q; q++)
+    {
+        if (strchr(ops1, *q))
+        {
+            size_t L = (size_t)(q - tok);
+            strncpy(field, tok, L);
+            field[L] = 0;
+            op[0] = *q;
+            op[1] = 0;
+            strcpy(val, q + 1);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+// tokenize by spaces, honoring quotes
+static int next_token(const char **p, char *buf, size_t bufsz)
+{
+    const char *s = *p;
+    while (*s && isspace((unsigned char)*s))
+        s++;
+    if (!*s)
+    {
+        *p = s;
+        return 0;
+    }
+
+    char *o = buf;
+    size_t left = bufsz - 1;
+    int q = 0;
+    char qc = 0;
+    for (; *s && left > 0; s++)
+    {
+        if (!q && isspace((unsigned char)*s))
+            break;
+        if (!q && (*s == '"' || *s == '\''))
+        {
+            q = 1;
+            qc = *s;
+        }
+        else if (q && *s == qc)
+        {
+            q = 0;
+        }
+        else
+        {
+            *o++ = *s;
+            left--;
+        }
+    }
+    *o = 0;
+    *p = s;
+    return 1;
+}
+
+// --- public: parse and match ---
+
+int query_parse(const char *expr, int case_insensitive, Query *out, char *errmsg, size_t errmsg_sz)
+{
+    memset(out, 0, sizeof(*out));
+    out->case_insensitive = case_insensitive;
+
+    const char *p = expr;
+    char tok[2048];
+    while (next_token(&p, tok, sizeof(tok)))
+    {
+        if (out->count >= (int)(sizeof(out->terms) / sizeof(out->terms[0])))
+        {
+            snprintf(errmsg, errmsg_sz, "too many terms");
+            return 0;
+        }
+        char field[64], op[3], val[1024];
+        if (!split_token(tok, field, op, val))
+        {
+            snprintf(errmsg, errmsg_sz, "bad token: %s", tok);
+            return 0;
+        }
+        unquote(val);
+
+        QueryTerm *t = &out->terms[out->count];
+        if (!map_field(field, &t->field))
+        {
+            snprintf(errmsg, errmsg_sz, "unknown field: %s", field);
+            return 0;
+        }
+
+        if (strcmp(op, ":") == 0)
+            t->op = QOP_CONTAINS; // string contains / wildcard; numeric == for status
+        else if (strcmp(op, "=") == 0)
+            t->op = QOP_EQ;
+        else if (strcmp(op, "!=") == 0)
+            t->op = QOP_NE;
+        else if (strcmp(op, ">") == 0)
+            t->op = QOP_GT;
+        else if (strcmp(op, "<") == 0)
+            t->op = QOP_LT;
+        else if (strcmp(op, ">=") == 0)
+            t->op = QOP_GTE;
+        else if (strcmp(op, "<=") == 0)
+            t->op = QOP_LTE;
+        else
+        {
+            snprintf(errmsg, errmsg_sz, "bad op: %s", op);
+            return 0;
+        }
+
+        strncpy(t->value, val, sizeof(t->value) - 1);
+
+        // pre-parse numeric/time
+        if (t->field == QF_STATUS)
+        {
+            t->value_i = atoi(val);
+            t->has_i = 1;
+        }
+        else if (t->field == QF_TIMESTAMP)
+        {
+            time_t tt;
+            if (parse_iso_utc(val, &tt))
+            {
+                t->value_t = tt;
+                t->has_t = 1;
+            }
+            // else leave as string; you could also support Apache format later
+        }
+        out->count++;
+    }
+    return 1;
+}
+
+static int cmp_int(int a, QueryOp op, int b)
+{
+    switch (op)
+    {
+    case QOP_EQ:
+        return a == b;
+    case QOP_NE:
+        return a != b;
+    case QOP_GT:
+        return a > b;
+    case QOP_LT:
+        return a < b;
+    case QOP_GTE:
+        return a >= b;
+    case QOP_LTE:
+        return a <= b;
+    default:
+        return 0;
+    }
+}
+static int cmp_time(time_t a, QueryOp op, time_t b) { return cmp_int((int)a, op, (int)b); }
+
+int query_match(const LogEntry *e, const Query *q)
+{
+    for (int i = 0; i < q->count; i++)
+    {
+        const QueryTerm *t = &q->terms[i];
+        int ok = 0;
+        switch (t->field)
+        {
+        case QF_STATUS:
+        {
+            if (t->op == QOP_CONTAINS || !t->has_i)
+            { // treat as string contains on decimal
+                char buf[16];
+                snprintf(buf, sizeof(buf), "%d", e->status);
+                ok = wildcard_match(buf, t->value, 1);
+            }
+            else
+            {
+                ok = cmp_int(e->status, t->op, t->value_i);
+            }
+        }
+        break;
+        case QF_TIMESTAMP:
+        {
+            if (t->has_t)
+                ok = cmp_time(e->epoch, t->op, t->value_t);
+            else
+                ok = wildcard_match(e->timestamp, t->value, q->case_insensitive);
+        }
+        break;
+        case QF_IP:
+            ok = wildcard_match(e->ip, t->value, q->case_insensitive);
+            break;
+        case QF_METHOD:
+            ok = wildcard_match(e->method, t->value, q->case_insensitive);
+            break;
+        case QF_URL:
+            ok = wildcard_match(e->url, t->value, q->case_insensitive);
+            break;
+        case QF_USERAGENT:
+            ok = wildcard_match(e->userAgent, t->value, q->case_insensitive);
+            break;
+        }
+        if (!ok)
+            return 0; // AND semantics
+    }
+    return 1;
+}
+
+// Case-insensitive substring search (portable)
+static int contains_ci(const char *hay, const char *needle)
+{
+    if (!hay || !needle)
+        return 0;
+    size_t hn = strlen(hay), nn = strlen(needle);
+    if (nn == 0)
+        return 1;
+    for (size_t i = 0; i + nn <= hn; i++)
     {
         size_t j = 0;
-        while (j < nl)
+        while (j < nn)
         {
-            unsigned char a = (unsigned char)h[i + j];
-            unsigned char b = (unsigned char)n[j];
+            unsigned char a = (unsigned char)hay[i + j];
+            unsigned char b = (unsigned char)needle[j];
             if (a >= 'A' && a <= 'Z')
-                a += 32;
+                a = (unsigned char)(a + 32);
             if (b >= 'A' && b <= 'Z')
-                b += 32;
+                b = (unsigned char)(b + 32);
             if (a != b)
                 break;
             j++;
         }
-        if (j == nl)
+        if (j == nn)
             return 1;
     }
     return 0;
 }
 
-/**
- * Checks if any field of the given LogEntry contains the specified needle string.
- *
- * @param e      Pointer to the LogEntry structure to search within.
- * @param needle The substring to search for in the LogEntry fields.
- * @param ci     If non-zero, the search is case-insensitive; otherwise, it is case-sensitive.
- *
- * @return 1 if the needle is found in any of the LogEntry fields (method, url, userAgent, timestamp, ip),
- *         or if needle is NULL or empty; 0 otherwise.
- */
-int matches(const LogEntry *e, const char *needle, int ci)
+int matches(const LogEntry *e, const char *needle, int case_insensitive)
 {
-    if (!needle || !*needle)
-        return 1;
-    if (ci)
+    if (!needle || needle[0] == '\0')
+        return 1; // no filter -> match all
+
+    if (case_insensitive)
     {
         return contains_ci(e->method, needle) ||
                contains_ci(e->url, needle) ||

--- a/src/tail.c
+++ b/src/tail.c
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#define _FILE_OFFSET_BITS 64
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#ifdef _WIN32
+#include <windows.h>
+static void msleep(int ms) { Sleep(ms); }
+#else
+#include <unistd.h>
+static void msleep(int ms) { usleep(ms * 1000); }
+#endif
+
+#include "cli.h"
+#include "logstore.h"
+#include "query.h"
+#include "parser.h"
+#include "formatter.h"
+
+char *read_line_dyn(FILE *fp);
+
+static int stat_inode(const char *path, dev_t *dev, ino_t *ino, off_t *size)
+{
+    struct stat st;
+    if (stat(path, &st) != 0)
+        return 0;
+    if (dev)
+        *dev = st.st_dev;
+    if (ino)
+        *ino = st.st_ino;
+    if (size)
+        *size = st.st_size;
+    return 1;
+}
+
+/**
+ * @brief Continuously tails a log file, optionally filtering and formatting output.
+ *
+ * This function opens the specified log file and continuously reads new lines as they are appended,
+ * similar to the Unix `tail -f` command. It supports filtering log entries using a query or search term,
+ * and can output results in different formats (text, JSON, CSV). The function also handles log rotation
+ * by detecting file truncation or inode changes and reopening the file as needed.
+ *
+ * @param path         Path to the log file to tail.
+ * @param from_start   If non-zero, start reading from the beginning of the file; otherwise, start from the end.
+ * @param opt          Pointer to CLIOptions structure containing user options (query, search term, format, etc.).
+ * @param out          Output stream to write matching log entries.
+ *
+ * The function will print warnings to stderr if parsing fails and the 'strict' option is enabled.
+ * It uses helper functions for parsing log lines, matching queries, and formatting output.
+ */
+void tail_file(const char *path, int from_start, const CLIOptions *opt, FILE *out)
+{
+    FILE *fp = fopen(path, "rb");
+    if (!fp)
+    {
+        perror(path);
+        return;
+    }
+
+    dev_t cur_dev = 0;
+    ino_t cur_ino = 0;
+    off_t cur_size = 0;
+    stat_inode(path, &cur_dev, &cur_ino, &cur_size);
+
+    if (!from_start)
+        fseeko(fp, 0, SEEK_END);
+
+    Query q;
+    int use_q = 0;
+    char qerr[128] = {0};
+    if (opt->query && *opt->query)
+    {
+        if (query_parse(opt->query, opt->case_insensitive, &q, qerr, sizeof(qerr)))
+        {
+            use_q = 1;
+        }
+        else
+        {
+            fprintf(stderr, "query parse error: %s\n", qerr);
+        }
+    }
+
+    for (;;)
+    {
+        long pos_before = ftello(fp);
+        char *line = read_line_dyn(fp);
+
+        if (!line)
+        {
+            dev_t new_dev = 0;
+            ino_t new_ino = 0;
+            off_t new_size = 0;
+            if (stat_inode(path, &new_dev, &new_ino, &new_size))
+            {
+                if (new_size < pos_before)
+                {
+                    fclose(fp);
+                    fp = fopen(path, "rb");
+                    if (!fp)
+                    {
+                        msleep(250);
+                        continue;
+                    }
+                    if (!from_start)
+                        fseeko(fp, 0, SEEK_END);
+                    cur_dev = new_dev;
+                    cur_ino = new_ino;
+                    cur_size = new_size;
+                }
+                else if (new_ino != cur_ino || new_dev != cur_dev)
+                {
+                    fclose(fp);
+                    fp = fopen(path, "rb");
+                    if (!fp)
+                    {
+                        msleep(250);
+                        continue;
+                    }
+                    if (!from_start)
+                        fseeko(fp, 0, SEEK_END);
+                    cur_dev = new_dev;
+                    cur_ino = new_ino;
+                    cur_size = new_size;
+                }
+            }
+            msleep(200);
+            continue;
+        }
+
+        LogEntry e;
+        char perr[256] = {0};
+        if (parse_apache_or_nginx(line, &e, perr, sizeof(perr)))
+        {
+            int ok = 1;
+            if (use_q)
+                ok = query_match(&e, &q);
+            else if (opt->searchTerm && *opt->searchTerm)
+                ok = matches(&e, opt->searchTerm, opt->case_insensitive);
+
+            if (ok)
+            {
+                if (opt->format == FORMAT_JSON)
+                {
+                    printLogJSON(&e, out);
+                    fputc('\n', out);
+                }
+                else if (opt->format == FORMAT_CSV)
+                {
+                    printLogCSV(&e, out);
+                    fputc('\n', out);
+                }
+                else
+                {
+                    printLogText(&e, out);
+                    fputc('\n', out);
+                }
+            }
+        }
+        else if (opt->strict)
+        {
+            fprintf(stderr, "[tail warn] %s\n", perr[0] ? perr : "parse failed");
+            fprintf(stderr, "  >> %s\n", line);
+        }
+
+        free(line);
+    }
+
+    fclose(fp);
+}


### PR DESCRIPTION
…ased query, and NDJSON in tail mode

- Add portable tail implementation that follows files across truncation/ rotation using stat+polling (works on Linux, macOS, Windows).
- Add Linux-specific inotify tail (opt-in) to efficiently follow by name across rotations (tail -F–like behavior).
- Emit NDJSON (one JSON object per line) in tail mode; batch mode keeps JSON arrays [ ... ].
- Integrate field-based query engine:
  - --query "status>=500 ip:10.*" (AND semantics, wildcards for strings)
  - numeric compares for status, ISO8601 compares for timestamp
  - case-insensitive matching via --ci
- Keep keyword search via --search (falls back when --query not given).
- CLI additions/changes:
  - --tail / -f: follow a single file (not stdin)
  - --from-start: with --tail, start at beginning (default: end)
  - --log - reads from stdin (default when no inputs)
  - warn if both --query and --search are supplied (use --query)
- Streaming pipeline stays O(1) memory; no fixed MAX_LOGS buffer.

Why
----
Community feedback highlighted pipeline usability, memory usage on large logs, correctness of JSON/CSV output, and need for real-time filtering. This brings Logfire closer to a practical, mini-ELK experience while remaining lightweight.

Build notes
-----------
- Define _FILE_OFFSET_BITS=64 for large files.
- For Linux builds with timegm/inotify, define -D_GNU_SOURCE.
- If keeping both tails, expose tail_file() as a wrapper that picks inotify on Linux and portable otherwise.

Test plan
---------
- Batch JSON array: gunzip -c access.log.1.gz | ./logfire --log - --format json > out.json
- Keyword search (case-insensitive): ./logfire --log access.log --search 'post' --ci --format csv
- Field query: ./logfire --log access.log --query 'status>=400 url:*login*'
- Tail (portable/inotify): ./logfire --log access.log --tail --query 'status>=500' --format json Append lines to access.log and observe NDJSON output.
- Rotation: mv access.log access.log.1 && touch access.log Append new lines; verify it continues following.

Docs
----
- Updated CLI help text in --help output (examples included).
- README to note NDJSON in tail mode and new flags.